### PR TITLE
Correction to easy_install Command Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ python setup.py blahhhh.
 
 ## Install from PyPi
 
-pip install gmvault or easy_install install gmvault
+    pip install gmvault
+
+or
+
+    easy_install gmvault
 
 ## gmvault 2 mins start 
 


### PR DESCRIPTION
easy_install takes the package name directly as its parameter, without 'install'.
I also added indentation, so that the commands get syntax highlighted.
