### PR TITLE
Add ability to export from gmvault's internal storage to standard formats

### DIFF
--- a/src/gmv/gmv_cmd.py
+++ b/src/gmv/gmv_cmd.py
@@ -547,8 +547,6 @@ class GMVaultLauncher(object):
     
     @classmethod
     def _export(cls, args):
-        # TODO: Encryption, hard-links,
-        # resumable/syncable, colon, trash/spam, timestamps
         types = { 'maildir': gmvault_export.Maildir,
             'mbox': gmvault_export.MBox }
         output = types[args['type']](args['output'])

--- a/src/gmv/gmvault_export.py
+++ b/src/gmv/gmvault_export.py
@@ -16,6 +16,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
+# TODO
+# Allow syncing, aka resumability after a partial or complete export
+# Test other OSes that might not like colon in Maildir filenames
+# Use hard-links to save space?
+
 import os
 import re
 import mailbox
@@ -51,6 +56,7 @@ class GMVaultExporter(object):
     def export_ids(self, kind, ids, default_folder, use_labels):
         timer = Timer()
         timer.start()
+        LOG.critical("Start %s export" % (kind,))
         done = 0
 
         for a_id in ids:
@@ -69,6 +75,8 @@ class GMVaultExporter(object):
                 LOG.critical("== Exported %d %s in %s, %d left (time estimate %s) ==" % \
                     (done, kind, timer.seconds_to_human_time(elapsed), \
                      left, timer.estimate_time_left(done, elapsed, left)))
+
+        LOG.critical("Export complete in %s" % (timer.elapsed_human_time(),))
 
 
 class Mailbox(object):


### PR DESCRIPTION
Fixes issue 68: https://github.com/gaubert/gmvault/issues/68 .

The command to export is: gmvault export -d DB_DIR -t FORMAT OUTPUT_DIR

Currently valid formats are 'maildir' and 'mbox'. The maildir variant is 'Maildir++' as used by dovecote, and indeed the exported maildir can be used as-is as a dovecote backend. The original 'mboxo' variant of mbox is used, with '.sbd' as a suffix for directories as used by Thunderbird.

As mentioned in the issue, the maildir (or mbox) format duplicates emails, once per label. This is clearly not optimal, but there's no way to avoid it. Users should continue to use gmvault's internal format for everyday use, only exporting to maildir when they need it.
