### PR TITLE
Dereference symbolic links in startup script

### DIFF
--- a/etc/scripts/gmvault
+++ b/etc/scripts/gmvault
@@ -8,7 +8,7 @@ umask 002
 #################################
 ## GMVAULT Distribution home directory
 #################################
-CDIR=`dirname "$0"`
+CDIR=`dirname "$(readlink -f $0)"`
 HERE=$(unset CDPATH; cd "$CDIR"; pwd)
 GMVAULT_HOME=$(unset CDPATH; cd "$HERE/.."; pwd)
 

--- a/etc/scripts/gmvault_mac
+++ b/etc/scripts/gmvault_mac
@@ -8,7 +8,8 @@ umask 002
 #################################
 ## GMVAULT Distribution home directory
 #################################
-CDIR=`dirname "$0"`
+ABSPATH="$(perl -e "use Cwd 'abs_path'; print abs_path('$0')")"
+CDIR=`dirname "$ABSPATH"`
 HERE=$(unset CDPATH; cd "$CDIR"; pwd)
 GMVAULT_HOME=$(unset CDPATH; cd "$HERE/.."; pwd)
 


### PR DESCRIPTION
Please merge these changes to support symbolic links to the startup script.  This is tested on Debian squeeze and Mac OSX 10.8.2 and work well whether the script is a symlink or not, or any parent folder in the script path is a symlink.

This allows gmvault to be installed in another location (e.g. /opt/gmvault/bin/gmvault) and to only symlink the startup script to exist in a standard location (/usr/local/bin/gmvault > /opt/gmvault/bin/gmvault).

On linux "readlink -f" is entirely standard and will recursively dereference correctly.

On OSX the "-f" option doesn't exist, and the standard readlink won't recursively dereference and will not return a value when the file is not a symlink.  Hence the choice to use perl as the shortest and most cross-platform solution available.  I considered using the python equivalent but perl tends to be more ubiquitous and consistent.
