### PR TITLE
Add date and time of sync to stdout

### DIFF
--- a/src/gmv/gmv_cmd.py
+++ b/src/gmv/gmv_cmd.py
@@ -555,7 +555,8 @@ class GMVaultLauncher(object):
         """
            Execute All synchronisation operations
         """
-        LOG.critical("Connect to Gmail server.\n")
+        now = datetime.datetime.now()
+        LOG.critical("Connect to Gmail server at %s.\n" % (now.isoformat()))
         
         # handle credential in all levels
         syncer = gmvault.GMVaulter(args['db-dir'], args['host'], args['port'], \


### PR DESCRIPTION
My gmvault sync is started with launchd and the output is directed to a log file. These log files have little context of when runs occurred, so this adds the date and time of the sync run. (The best context is if you're using a quick sync. Then the log includes how far back to look. Assuming the configuration isn't changing, you could extrapolate the date, but not time, of the sync.)

I considered trying to do this outside of gmvault. Unfortunately, launchd doesn't have any dependency management. Also, I think dates in logs are useful.

I didn't see any GitHub issues like this. Please point me in the right direction if this has been discussed before.

I didn't look too hard for automated tests, so I didn't run them. The testing I did was running quick sync a few times against my gmail. The runs were successful and had the expected console output.
