### PR TITLE
ignore build files from setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ gmvault.log
 .DS_Store
 dists/disstoolbox-dist/build
 dists/disstoolbox-dist/build/*
+build/
+gmvault.egg-info/
+


### PR DESCRIPTION
encountered when installing gmvault in a virtualenv
