### PR TITLE
fixed typo

### DIFF
--- a/src/gmv/gmv_cmd.py
+++ b/src/gmv/gmv_cmd.py
@@ -777,7 +777,7 @@ class GMVaultLauncher(object):
             on_error = False
         
         except KeyboardInterrupt, _:
-            LOG.critical("\nCRTL^C. Stop all operations.\n")
+            LOG.critical("\nCTRL-C. Stop all operations.\n")
             on_error = False
         except socket.error:
             LOG.critical("Error: Network problem. Please check your gmail server hostname,"\


### PR DESCRIPTION
1) It's CTRL, not CRTL.

2) You can say ^C, or you can say CTRL-C, but you can't say CTRL^C. 
