### PR TITLE
solving encoding problem when writing content to file.

### DIFF
--- a/src/gmv/gmvault_db.py
+++ b/src/gmv/gmvault_db.py
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 '''
+import codecs
 import json
 import gzip
 import re
@@ -400,7 +401,7 @@ class GmailStorer(object): #pylint:disable=R0902,R0904,R0914
         
         return self.bury_email(chat_info, local_dir, compress, extra_labels)
     
-    def bury_email(self, email_info, local_dir = None, compress = False, extra_labels = []): #pylint:disable=W0102
+    def bury_email(self, email_info, local_dir = None, compress = False, encoding = 'utf-8', extra_labels = []): #pylint:disable=W0102
         """
            store all email info in 2 files (.meta and .eml files)
            Arguments:
@@ -425,7 +426,7 @@ class GmailStorer(object): #pylint:disable=R0902,R0904,R0914
             data_path = '%s.gz' % (data_path)
             data_desc = gzip.open(data_path, 'wb')
         else:
-            data_desc = open(data_path, 'wb')
+            data_desc = codecs.open(data_path, 'wb', encoding)
             
         if self._encrypt_data:
             # need to be done for every encryption


### PR DESCRIPTION
Error: didn't recognize char u'\x92'. 

=== Exception traceback ===
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmv_cmd.py", line 760, in run
    self._sync(args, credential)
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmv_cmd.py", line 724, in _sync
    emails_only = args['emails_only'], chats_only = args['chats_only'])
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmvault.py", line 604, in sync
    self._sync_emails(imap_req, compress = compress_on_disk, restart = restart)
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmvault.py", line 567, in _sync_emails
    imap_ids = self._common_sync(timer, "email", imap_req, compress, restart)
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmvault.py", line 525, in _common_sync
    handle_sync_imap_error(error, the_id, self.error_report, self.src) #do everything in this handler
  File "/usr/local/lib/python2.6/dist-packages/gmv/gmvault.py", line 156, in handle_sync_imap_error
    raise the_exception
TypeError: can't write unicode to binary stream

=== End of Exception traceback ===