### PR TITLE
Use urllib2 else the request gets stuck

### DIFF
--- a/src/gmv/credential_utils.py
+++ b/src/gmv/credential_utils.py
@@ -24,6 +24,7 @@ import webbrowser
 import json
 import base64
 import urllib
+import urllib2
 
 import os
 import getpass
@@ -253,7 +254,7 @@ class CredentialHelper(object):
       request_url = '%s/%s' % (account_base_url, 'o/oauth2/token')
 
       try:
-        response = urllib.urlopen(request_url, urllib.urlencode(params)).read()
+        response = urllib2.urlopen(request_url, urllib.urlencode(params)).read()
       except Exception, err: #pylint: disable-msg=W0703
         LOG.critical("Error: Problems when trying to connect to Google oauth2 endpoint: %s.\n" % (request_url))
         raise err


### PR DESCRIPTION
Using urllib.urlopen on my system results in the request never finishing. Switching to urllib2 fixes the issue.

Ubuntu 14.10
Linux marc 3.16.0-34-generic #47-Ubuntu SMP Fri Apr 10 18:02:58 UTC 2015 x86_64 x86_64 x86_64 GNU/Linux