### PR TITLE
check for 'None' result before raising PushEmailError

### DIFF
--- a/src/gmv/imap_utils.py
+++ b/src/gmv/imap_utils.py
@@ -812,7 +812,7 @@ class GIMAPFetcher(object): #pylint:disable=R0902,R0904
                   % (a_flags, a_internal_time, the_timer.elapsed_ms(), res))
         
         # check res otherwise Exception
-        if '(Success)' not in res:
+        if res is None or '(Success)' not in res:
             raise PushEmailError("GIMAPFetcher cannot restore email in %s account." %(self.login))
         
         match = GIMAPFetcher.APPENDUID_RE.match(res)


### PR DESCRIPTION
This allows the retry() wrapper to work its magic when the result returned is `None`.

Hi @gaubert - please consider this patch related to issue #238.  It has resolved the issue for me as it allows the PushEmailError exception to be raised and handled by the retry wrapper.  The debug logs when this occurs contain:

```
[2016-08-23 03:12]:DEBUG:imap_utils:Appended data with flags [u'\\Seen'] and internal time 2003-10-24 15:11:53. Operation time = 1.57089304924.
res = None

[2016-08-23 03:12]:DEBUG:imap_utils:error message = GIMAPFetcher cannot restore email in foo@example.com account.. traceback:Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gmvault-1.9.1-py2.7.egg/gmv/imap_utils.py", line 132, in wrapper
    return the_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/gmvault-1.9.1-py2.7.egg/gmv/imap_utils.py", line 816, in push_data
    raise PushEmailError("GIMAPFetcher cannot restore email in %s account." %(self.login))
PushEmailError: GIMAPFetcher cannot restore email in foo@example.com account.

[2016-08-23 03:12]:CRITICAL:imap_utils:Cannot reach the Gmail server. Wait 1 second(s) and retrying.
[2016-08-23 03:12]:CRITICAL:imap_utils:Disconnecting from Gmail Server and sleeping ...
[2016-08-23 03:12]:CRITICAL:imap_utils:Reconnecting to the from Gmail Server.
[2016-08-23 03:12]:CRITICAL:credential_utils:Get OAuth2 credential from /home/foo/.gmvault/foo@example.com.oauth2.
...
```
