### PR TITLE
Fetch in the order of increasing imap_ids

### DIFF
--- a/src/gmv/gmvault.py
+++ b/src/gmv/gmvault.py
@@ -167,7 +167,7 @@ class IMAPBatchFetcher(object):
         self.request            = request
         self.error_report       = error_report  
         
-        self.to_fetch           = list(imap_ids)
+        self.to_fetch           = list(sorted(imap_ids))
     
     def individual_fetch(self, imap_ids):
         """


### PR DESCRIPTION
This should fix the last issue reported in #224 

Emails are fetched in the order of increasing imap ids, so the last_ids saved shoud truly be the last.