### PR TITLE
gmv_cmd: help message formatting

### DIFF
--- a/src/gmv/gmv_cmd.py
+++ b/src/gmv/gmv_cmd.py
@@ -210,7 +210,7 @@ class GMVaultLauncher(object):
                                  dest="imap_request", default=None)
         
         sync_parser.add_argument("-g", "--gmail-req", metavar = "REQ", \
-                                 help="Gmail search request to restrict sync as defined in"\
+                                 help="Gmail search request to restrict sync as defined in "\
                                       "https://support.google.com/mail/bin/answer.py?hl=en&answer=7190",\
                                  dest="gmail_request", default=None)
         


### PR DESCRIPTION
Previously `gmvault sync -h` outputs:

```
-g REQ, --gmail-req REQ
Gmail search request to restrict sync as defined inhtt
ps://support.google.com/mail/bin/answer.py?hl=en&answe r=7190
```

i.e. no space between `inhttps://...`

This commit fix this.

---
 src/gmv/gmv_cmd.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)