### PR TITLE
Preserve config for version 1.9.1 (the current one)

### DIFF
--- a/src/gmv/gmvault_utils.py
+++ b/src/gmv/gmvault_utils.py
@@ -640,7 +640,7 @@ VERSION_PATTERN  = r'\s*conf_version=\s*(?P<version>\S*)\s*'
 VERSION_RE  = re.compile(VERSION_PATTERN)
 
 #list of version conf to not overwrite with the next
-VERSIONS_TO_PRESERVE = [ '1.9' ]
+VERSIONS_TO_PRESERVE = [ '1.9', '1.9.1' ]
 
 def _get_version_from_conf(home_conf_file):
     """


### PR DESCRIPTION
Currently `~/.gmvault/gmvault_defaults.conf` gets overwritten every single time the program runs, because the default config contains version "1.9.1", but the code expects to find version "1.9" here. I'm assuming these are compatible, so there is no need to delete the config.