### PR TITLE
Work around crazy emails with non-base64 encoded attachments

### DIFF
--- a/src/gmv/imap_utils.py
+++ b/src/gmv/imap_utils.py
@@ -799,7 +799,11 @@ class GIMAPFetcher(object): #pylint:disable=R0902,R0904
         res = None
         try:
            #a_body = self._clean_email_body(a_body)
-           res = self.server.append(a_folder, a_body, a_flags, a_internal_time)
+           if b'\xc2\x89PNG' in a_body:
+               raise PushEmailError("Skip bad email with binary data. Quarantine this email.", quarantined = True)
+           else:
+               res = self.server.append(a_folder, a_body, a_flags, a_internal_time)
+
         except imaplib.IMAP4.abort, err:
            # handle issue when there are invalid characters (This is do to the presence of null characters)
            if str(err).find("APPEND => Invalid character in literal") >= 0:


### PR DESCRIPTION
GMail IMAP push will get in a weird state if it encounters an email
which is encoded in this manner. The connection will be reset after a
long timeout after encountering this binary crap.

I suspect an earlier version of GMail server software, or some non-IMAP
import allows or allowed this in at some point, and yet it is not
possible to upload it back verbatim.

For my purposes, it suffices to skip these rare species but in general
the email parts should be re-encoded as base64, or the problematic
invalidly encoded attachments should be removed.

The illegally encoded binary emails are detected here by looking for the
PNG magic string with bytes that SHOULD NOT appear in any legitimate
email data.

A screenshot of one of the affected emails is at
https://imgur.com/a/i09Xa.