### PR TITLE
Skip @eaDir directories

### DIFF
--- a/src/gmv/gmvault_db.py
+++ b/src/gmv/gmvault_db.py
@@ -129,6 +129,9 @@ class GmailStorer(object): #pylint:disable=R0902,R0904,R0914
         if os.path.exists(self._chats_dir):
             dirs = os.listdir(self._chats_dir)
             for the_dir in dirs:
+                if the_dir.startswith('@') or the_dir.startswith('#'):
+                    continue
+                    
                 the_split = the_dir.split("-")
                 if len(the_split) != 2:
                     raise Exception("Should get 2 elements in %s" % the_split)


### PR DESCRIPTION
I'm running on a Synology NAS and it creates some directories starting with `@` and `#` that are used for metadata and integrity info. This patch ignores those

```  File "/volume1/@appstore/python/lib/python2.7/site-packages/gmv/gmvault_db.py", line 137, in _init_sub_chats_dir
    raise Exception("Should get 2 elements in %s" % the_split)
Exception: Should get 2 elements in ['@eaDir']```