### PR TITLE
update version number

### DIFF
--- a/src/gmv/gmvault_utils.py
+++ b/src/gmv/gmvault_utils.py
@@ -640,7 +640,7 @@ VERSION_PATTERN  = r'\s*conf_version=\s*(?P<version>\S*)\s*'
 VERSION_RE  = re.compile(VERSION_PATTERN)
 
 #list of version conf to not overwrite with the next
-VERSIONS_TO_PRESERVE = [ '1.9' ]
+VERSIONS_TO_PRESERVE = [ '1.9.1' ]
 
 def _get_version_from_conf(home_conf_file):
     """


### PR DESCRIPTION
the number in the file written in gmvault_const.py is 1.9.1 - the mismatch currently causes the config file to be overwritten on every run. Updating this makes it work.