### PR TITLE
docs: fix simple typo, retrun -> return

### DIFF
--- a/src/gmv/gmvault_utils.py
+++ b/src/gmv/gmvault_utils.py
@@ -633,7 +633,7 @@ def get_conf_defaults():
         
         return the_cf
     else:
-        return gmv.conf.conf_helper.MockConf() #retrun MockObject that will play defaults
+        return gmv.conf.conf_helper.MockConf() #return MockObject that will play defaults
     
 #VERSION DETECTION PATTERN
 VERSION_PATTERN  = r'\s*conf_version=\s*(?P<version>\S*)\s*'


### PR DESCRIPTION
There is a small typo in src/gmv/gmvault_utils.py.

Should read `return` rather than `retrun`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md